### PR TITLE
feat: add support for migration strategies

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,6 +1,6 @@
 ---
 
-extends: "default"
+extends: default
 
 ignore: |
   .build/
@@ -51,8 +51,6 @@ rules:
     require-starting-space: true
     min-spaces-from-content: 1
 
-yaml-files:
-  - "*.yaml"
-  - "*.yml"
+  line-length: disable
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,9 @@ hooks: ## Install git hooks from pre-commit-config
 	pre-commit autoupdate
 .PHONY: hooks
 
+lint: lint-yaml lint-php lint-stan ## Runs all linting commands
+.PHONY: lint
+
 lint-yaml: ## Lints yaml files inside project
 	yamllint .
 .PHONY: lint-yaml

--- a/config/cycle.php
+++ b/config/cycle.php
@@ -13,7 +13,7 @@ use WayOfDev\Cycle\Contracts\GeneratorLoader;
 return [
     /*
      * Where ClassLocator should search for entities and embeddings.
-     * Important: By default, Laravel's application skeleton has its Model classes in the app/Models folder.
+     * Important: By default, Laravel application skeleton has its Model classes in the app/Models folder.
      * With Cycle you'll need to create a dedicated folder for your Entities and point your config/cycle.php
      * paths array to it. If you don't, Cycle will scan your whole app/ folder for files,
      * which will have a huge impact on performance!
@@ -228,9 +228,9 @@ return [
 
     'migrations' => [
         'directory' => database_path('migrations/cycle'),
-
+        'strategy' => Schema\Generator\Migrations\Strategy\SingleFileStrategy::class,
+        'nameGenerator' => Schema\Generator\Migrations\NameBasedOnChangesGenerator::class,
         'table' => env('DB_MIGRATIONS_TABLE', 'cycle_migrations'),
-
         'safe' => env('APP_ENV') !== 'production',
     ],
 
@@ -253,5 +253,7 @@ return [
      * Enables support of SoftDelete and other features from cycle/entity-behavior package
      * @see https://github.com/cycle/entity-behavior
      */
-    'load_cycle_behavior' => true,
+    'entityBehavior' => [
+        'register' => true,
+    ],
 ];

--- a/src/Bridge/Laravel/Providers/Registrators/RegisterMigrations.php
+++ b/src/Bridge/Laravel/Providers/Registrators/RegisterMigrations.php
@@ -9,6 +9,10 @@ use Cycle\Migrations\Config\MigrationConfig;
 use Cycle\Migrations\FileRepository;
 use Cycle\Migrations\Migrator;
 use Cycle\Migrations\RepositoryInterface;
+use Cycle\Schema\Generator\Migrations\NameBasedOnChangesGenerator;
+use Cycle\Schema\Generator\Migrations\NameGeneratorInterface;
+use Cycle\Schema\Generator\Migrations\Strategy\GeneratorStrategyInterface;
+use Cycle\Schema\Generator\Migrations\Strategy\SingleFileStrategy;
 use Illuminate\Contracts\Foundation\Application;
 
 /**
@@ -24,6 +28,20 @@ final class RegisterMigrations
             return new FileRepository(
                 config: $config,
             );
+        });
+
+        $app->singleton(NameGeneratorInterface::class, static function (Application $app): NameGeneratorInterface {
+            $config = $app->get(MigrationConfig::class);
+            $nameGenerator = $config->toArray()['nameGenerator'] ?? NameBasedOnChangesGenerator::class;
+
+            return $app->get($nameGenerator);
+        });
+
+        $app->singleton(GeneratorStrategyInterface::class, static function (Application $app): GeneratorStrategyInterface {
+            $config = $app->get(MigrationConfig::class);
+            $strategy = $config->toArray()['strategy'] ?? SingleFileStrategy::class;
+
+            return $app->get($strategy);
         });
 
         $app->singleton(Migrator::class, static function (Application $app): Migrator {

--- a/src/Bridge/Laravel/Providers/Registrators/RegisterORM.php
+++ b/src/Bridge/Laravel/Providers/Registrators/RegisterORM.php
@@ -41,7 +41,7 @@ final class RegisterORM
 
         $app->singleton(ORMInterface::class, function (Application $app): ORMInterface {
             $commandGenerator = null;
-            $loadEntityBehavior = config('cycle.load_entity_behavior', true);
+            $loadEntityBehavior = config('cycle.entityBehavior.register', true);
 
             if (true === $loadEntityBehavior) {
                 $commandGenerator = new EventDrivenCommandGenerator($app->get(SchemaInterface::class), $app);

--- a/tests/src/Bridge/Laravel/Providers/Registrators/RegisterMigrationsTest.php
+++ b/tests/src/Bridge/Laravel/Providers/Registrators/RegisterMigrationsTest.php
@@ -4,8 +4,14 @@ declare(strict_types=1);
 
 namespace WayOfDev\Tests\Bridge\Laravel\Providers\Registrators;
 
+use Cycle\Migrations\Config\MigrationConfig;
 use Cycle\Migrations\Migrator;
 use Cycle\Migrations\RepositoryInterface;
+use Cycle\Schema\Generator\Migrations\NameBasedOnChangesGenerator;
+use Cycle\Schema\Generator\Migrations\NameGeneratorInterface;
+use Cycle\Schema\Generator\Migrations\Strategy\GeneratorStrategyInterface;
+use Cycle\Schema\Generator\Migrations\Strategy\MultipleFilesStrategy;
+use Cycle\Schema\Generator\Migrations\Strategy\SingleFileStrategy;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
 use WayOfDev\Tests\TestCase;
@@ -44,5 +50,57 @@ class RegisterMigrationsTest extends TestCase
         $this::assertInstanceOf(Migrator::class, $class1);
 
         $this::assertSame($class1, $class2);
+    }
+
+    /**
+     * @test
+     */
+    public function it_registers_name_generator_interface_as_expected(): void
+    {
+        $this->app->instance(MigrationConfig::class, new MigrationConfig([
+            'nameGenerator' => NameBasedOnChangesGenerator::class,
+        ]));
+
+        try {
+            $nameGenerator = $this->app->get(NameGeneratorInterface::class);
+        } catch (NotFoundExceptionInterface|ContainerExceptionInterface $e) {
+            $this::fail($e->getMessage());
+        }
+
+        $this::assertInstanceOf(NameBasedOnChangesGenerator::class, $nameGenerator);
+    }
+
+    /**
+     * @test
+     */
+    public function it_registers_generator_strategy_interface_as_expected(): void
+    {
+        $this->app->instance(MigrationConfig::class, new MigrationConfig([
+            'strategy' => SingleFileStrategy::class,
+        ]));
+
+        try {
+            $strategy = $this->app->get(GeneratorStrategyInterface::class);
+        } catch (NotFoundExceptionInterface|ContainerExceptionInterface $e) {
+            $this::fail($e->getMessage());
+        }
+
+        $this::assertInstanceOf(SingleFileStrategy::class, $strategy);
+    }
+
+    /**
+     * @test
+     */
+    public function it_registers_generator_strategy_with_multiple_files_strategy_in_config(): void
+    {
+        config()->set('cycle.migrations.strategy', MultipleFilesStrategy::class);
+
+        try {
+            $strategy = $this->app->get(GeneratorStrategyInterface::class);
+        } catch (NotFoundExceptionInterface|ContainerExceptionInterface $e) {
+            $this::fail($e->getMessage());
+        }
+
+        $this::assertInstanceOf(MultipleFilesStrategy::class, $strategy);
     }
 }

--- a/tests/src/Bridge/Laravel/Providers/Registrators/RegisterORMTest.php
+++ b/tests/src/Bridge/Laravel/Providers/Registrators/RegisterORMTest.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace WayOfDev\Tests\Bridge\Laravel\Providers\Registrators;
 
+use Cycle\ORM\Entity\Behavior\EventDrivenCommandGenerator;
 use Cycle\ORM\Factory;
 use Cycle\ORM\FactoryInterface;
 use Cycle\ORM\ORM;
 use Cycle\ORM\ORMInterface;
+use Cycle\ORM\Transaction\CommandGenerator;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
 use WayOfDev\Tests\TestCase;
@@ -45,5 +47,36 @@ class RegisterORMTest extends TestCase
         $this::assertInstanceOf(ORM::class, $class1);
 
         $this::assertSame($class1, $class2);
+    }
+
+    /**
+     * @test
+     */
+    public function it_registers_entity_behavior_by_default(): void
+    {
+        try {
+            $class = $this->app->get(ORMInterface::class);
+        } catch (NotFoundExceptionInterface|ContainerExceptionInterface $e) {
+            $this::fail($e->getMessage());
+        }
+
+        $this::assertInstanceOf(EventDrivenCommandGenerator::class, $class->getCommandGenerator());
+    }
+
+    /**
+     * @test
+     */
+    public function it_disables_entity_behavior_by_default(): void
+    {
+        config()->set('cycle.entityBehavior.register', false);
+
+        try {
+            /** @var ORM $class */
+            $class = $this->app->get(ORMInterface::class);
+        } catch (NotFoundExceptionInterface|ContainerExceptionInterface $e) {
+            $this::fail($e->getMessage());
+        }
+
+        $this::assertInstanceOf(CommandGenerator::class, $class->getCommandGenerator());
     }
 }


### PR DESCRIPTION
This adds support to change default migration strategy, which allows to generate migrations in one single file, or in multiple. Based on PR https://github.com/spiral/cycle-bridge/compare/v2.5.0...v2.6.0