### PR TITLE
chore: add telescope entities

### DIFF
--- a/src/Bridge/Telescope/Entities/TelescopeEntry.php
+++ b/src/Bridge/Telescope/Entities/TelescopeEntry.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WayOfDev\Cycle\Bridge\Telescope\Entities;
+
+use Cycle\Annotated\Annotation\Column;
+use Cycle\Annotated\Annotation\Entity;
+use Cycle\Annotated\Annotation\Table\Index;
+use DateTimeImmutable;
+
+#[Index(columns: ['batch_id'])]
+#[Index(columns: ['family_hash'])]
+#[Index(columns: ['created_at'])]
+#[Index(columns: ['type', 'should_display_on_index'])]
+#[Entity(table: 'telescope_entries')]
+class TelescopeEntry
+{
+    #[Column(type: 'bigInteger', primary: true)]
+    public int $sequence;
+
+    #[Column(type: 'uuid', unique: true)]
+    public string $uuid;
+
+    #[Column(type: 'uuid')]
+    public string $batchId;
+
+    #[Column(type: 'string', nullable: true)]
+    public string $familyHash;
+
+    #[Column(type: 'boolean', default: true)]
+    public bool $shouldDisplayOnIndex;
+
+    #[Column(type: 'string', size: 20)]
+    public string $type;
+
+    #[Column(type: 'longText')]
+    public string $content;
+
+    #[Column(type: 'datetime', nullable: true)]
+    public ?DateTimeImmutable $createdAt;
+}

--- a/src/Bridge/Telescope/Entities/TelescopeEntryTags.php
+++ b/src/Bridge/Telescope/Entities/TelescopeEntryTags.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WayOfDev\Cycle\Bridge\Telescope\Entities;
+
+use Cycle\Annotated\Annotation\Column;
+use Cycle\Annotated\Annotation\Entity;
+use Cycle\Annotated\Annotation\ForeignKey;
+use Cycle\Annotated\Annotation\Relation\HasMany;
+use Cycle\Annotated\Annotation\Table\Index;
+use Illuminate\Support\Collection;
+
+#[Index(columns: ['entry_uuid', 'tag'])]
+#[Index(columns: ['tag'])]
+#[ForeignKey(target: TelescopeEntry::class, innerKey: 'entry_uuid', outerKey: 'uuid', action: 'CASCADE')]
+#[Entity(table: 'telescope_entry_tags')]
+class TelescopeEntryTags
+{
+    #[Column(type: 'uuid', primary: true)]
+    public string $entryUuid;
+
+    #[Column(type: 'string')]
+    public string $tag;
+}

--- a/src/Bridge/Telescope/Entities/TelescopeMonitoring.php
+++ b/src/Bridge/Telescope/Entities/TelescopeMonitoring.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WayOfDev\Cycle\Bridge\Telescope\Entities;
+
+use Cycle\Annotated\Annotation\Column;
+use Cycle\Annotated\Annotation\Entity;
+
+#[Entity(table: 'telescope_monitoring')]
+class TelescopeMonitoring
+{
+    #[Column(type: 'string', primary: true)]
+    public string $tag;
+}

--- a/tests/src/TestCase.php
+++ b/tests/src/TestCase.php
@@ -9,7 +9,6 @@ use Faker\Generator;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Support\Facades\Artisan;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
-use Spatie\LaravelRay\RayServiceProvider;
 use WayOfDev\Cycle\Bridge\Laravel\Providers\CycleServiceProvider;
 use WayOfDev\Cycle\Testing\Concerns\InteractsWithDatabase;
 use WayOfDev\Cycle\Testing\RefreshDatabase;
@@ -53,7 +52,8 @@ class TestCase extends OrchestraTestCase
             config()->set([
                 'cycle.tokenizer.directories' => array_merge(
                     config('cycle.tokenizer.directories'),
-                    [__DIR__ . '/../app/Entities']
+                    [__DIR__ . '/../app/Entities'],
+                    // [__DIR__ . '/../../src/Bridge/Telescope/Entities'],
                 ),
                 'cycle.migrations.directory' => $this->migrationsPath,
             ]);
@@ -99,7 +99,6 @@ class TestCase extends OrchestraTestCase
     {
         return [
             CycleServiceProvider::class,
-            RayServiceProvider::class,
         ];
     }
 }


### PR DESCRIPTION
Entities added to exclude the need to run native laravel migration command, when installing laravel/telescope.

