### PR TITLE
Don't merge config if the config has been published

### DIFF
--- a/src/Bridge/Laravel/Providers/CycleServiceProvider.php
+++ b/src/Bridge/Laravel/Providers/CycleServiceProvider.php
@@ -46,7 +46,17 @@ final class CycleServiceProvider extends ServiceProvider
     }
 
     public function register(): void
-    {        
+    {
+        $config = $this->app->make('config');
+
+        // @phpstan-ignore-next-line
+        if (! $this->app->configurationIsCached() && ! $config->get('cycle')) {
+            $this->mergeConfigFrom(
+                __DIR__ . '/../../../../config/cycle.php',
+                Registrator::CFG_KEY
+            );
+        }
+
         $registrators = [
             Registrators\RegisterConfigs::class,
             Registrators\RegisterTokenizer::class,

--- a/src/Bridge/Laravel/Providers/CycleServiceProvider.php
+++ b/src/Bridge/Laravel/Providers/CycleServiceProvider.php
@@ -46,15 +46,7 @@ final class CycleServiceProvider extends ServiceProvider
     }
 
     public function register(): void
-    {
-        // @phpstan-ignore-next-line
-        if (! $this->app->configurationIsCached()) {
-            $this->mergeConfigFrom(
-                __DIR__ . '/../../../../config/cycle.php',
-                Registrator::CFG_KEY
-            );
-        }
-
+    {        
         $registrators = [
             Registrators\RegisterConfigs::class,
             Registrators\RegisterTokenizer::class,


### PR DESCRIPTION
<!-- Welcome to Contributors! 🌟 -->
<!-- If you're making a significant change, please open an issue first to discuss. This ensures we all agree on the solution before you invest time in coding. -->

## 🔍 Changes Made

I added a condition to not run the mergeConfigFrom in the CycleServiceProvider if the config already has been published.

## 🤔 Rationale

<!-- Why are these changes necessary? Link to any related discussions in GitHub issues or explain your reasoning here. This context is crucial for reviewers to assess the relevance and impact of your changes. -->

If you do not have pdo_mysql installed (and likely the case with other pdo extensions), you will get an `Undefined constant PDO::MYSQL_ATTR_INIT_COMMAND` error, because the MysqlConfig class will get instantiated even if you remove it from the published config or set it to an empty value. 

## 📋 Checklist

<!-- Review this checklist and confirm you’ve addressed these items before submitting your PR -->
<!-- Use UI to check the items that apply, or use [x] to mark it. -->

- [x] My code follows the contributing guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if necessary)
- [x] Tests via `make test` passes locally with my changes
- [] Linting via `make lint` passes locally with my changes - Invalid configuration errors

## 🧪 Added or updated tests?

<!-- How should reviewers verify your changes? This can be as simple as "Ran unit tests"
or more detailed like "Tested on staging with multiple environments."
More details help ensure reliability. -->

- [ ] Yes
- [x] No, and this is why: Tested locally, change doesn't need a unit test
- [ ] I need help with writing tests
